### PR TITLE
Remove covr from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,5 @@ Imports:
 Suggests: 
     coarseDataTools,
     fitdistrplus,
-    covr,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3


### PR DESCRIPTION
The same way we don't include pkgdown in `Suggests`, we shouldn't include covr, which is only used as part of a user-invisible development process. This also removes some of the reverse dependency checking burden for this package.