### PR TITLE
Fix ORCID links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,11 +4,11 @@ Title: Utility functions for fitting and comparing simple epidemiological
 Version: 0.0.0.9000
 Authors@R: c(
     person("Joshua W.", "Lambert", , "joshua.lambert@lshtm.ac.uk", role = c("aut", "cre"),
-           comment = c(ORCID = "https://orcid.org/0000-0001-5218-3046")),
+           comment = c(ORCID = "0000-0001-5218-3046")),
     person("Adam", "Kucharski", , "adam.kucharski@lshtm.ac.uk", role = "aut",
-           comment = c(ORCID = "https://orcid.org/0000-0001-8814-9421")),
+           comment = c(ORCID = "0000-0001-8814-9421")),
     person("Pratik", "Gupte", , "pratik.gupte@lshtm.ac.uk", role = "aut",
-           comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819"))
+           comment = c(ORCID = "0000-0001-5294-7819"))
   )
 Description: Model fitting utilities package for Epiverse-TRACE.
 License: MIT + file LICENSE


### PR DESCRIPTION
This PR fixes the ORCID links for the `pkgdown` page. See also upstream change to the template - https://github.com/epiverse-trace/packagetemplate/pull/126