### PR TITLE
Add lintr GHA workflow

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -1,0 +1,52 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - '**.R'
+      - '**.Rmd'
+      - '**/.lintr'
+      - '**/.lintr.R'
+
+name: lint-changed-files
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-changed-files:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::gh
+            any::lintr
+            any::purrr
+            epiverse-trace/etdev
+          needs: check
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Extract and lint files changed by this PR
+        run: |
+          files <- gh::gh("/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          changed_files <- purrr::map_chr(files, "filename")
+          all_files <- list.files(recursive = TRUE)
+          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          lintr::lint_package(exclusions = exclusions_list)
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.lintr
+++ b/.lintr
@@ -1,11 +1,38 @@
-linters: linters_with_tags(
-    tags = NULL, # include all linters
+linters: all_linters(
+    packages = c("lintr", "etdev"),
     object_name_linter = NULL,
-    undesirable_function_linter = NULL,
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
+    library_call_linter = NULL,
+    undesirable_function_linter(
+      modify_defaults(
+        default_undesirable_functions,
+        citEntry = "use the more modern bibentry() function",
+        library = NULL # too many false positive in too many files
+      )
+    ),
     function_argument_linter = NULL,
-    # Use minimum R declared in DESCRIPTION or fall back to current R version
+    indentation_linter = NULL, # unstable as of lintr 3.1.0
+    # Use minimum R declared in DESCRIPTION or fall back to current R version.
+    # Install etdev package from https://github.com/epiverse-trace/etdev
     backport_linter(if (length(x <- etdev::extract_min_r_version())) x else getRversion())
+  )
+exclusions: list(
+    "tests/testthat.R" = list(
+      unused_import_linter = Inf
+    ),
+    "tests" = list(
+      undesirable_function_linter = Inf
+    ),
+    "data-raw" = list(
+      missing_package_linter = Inf,
+      namespace_linter = Inf
+    ),
+    # RcppExports.R is auto-generated and will not pass many linters. In
+    # particular, it can create very long lines.
+    "R/RcppExports.R",
+    # R/stanmodels.R is auto-generated and will not pass many linters. In
+    # particular, it uses `sapply()`.
+    "R/stanmodels.R"
   )


### PR DESCRIPTION
This PR reintroduces the `lint-changed-files.yaml` GitHub actions workflow as it is no longer being triggered at the organisation level. The `.lintr` config file is also updated.